### PR TITLE
fix: add userId to submission when user is created

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -7,7 +7,7 @@ const load = async () => {
   try {
     await prisma.quiz.deleteMany()
 
-    for (let qi = 0; qi <= 10; qi++) {
+    for (let qi = 0; qi <= 1; qi++) {
       const quiz = await prisma.quiz.create({
         data: {
           title: qi % 2 === 0 ? 'Desenvolvimento web' : 'React',

--- a/src/server/router/report.ts
+++ b/src/server/router/report.ts
@@ -103,8 +103,20 @@ export const reportRouter = createRouter()
           data: {
             email: input.email,
             submissions: {
-              create: submission,
+              connect: {
+                id: submission.id,
+              },
             },
+          },
+        })
+
+        await ctx.prisma.submission.update({
+          where: {
+            id: submission.id,
+          },
+          data: {
+            userId: user.id,
+            sessionId: null,
           },
         })
 


### PR DESCRIPTION
When the report is sent, if the user doest not exist on the database, adds the `userId` and remove the `sessionId` from the recently created user to the `submission`. 